### PR TITLE
空值检查和非 string 值 的 toString() 

### DIFF
--- a/sdk/requests/acs_reqeust.go
+++ b/sdk/requests/acs_reqeust.go
@@ -20,6 +20,7 @@ import (
 	"io"
 	"reflect"
 	"strconv"
+	"github.com/aliyun/alibaba-cloud-sdk-go/sdk/utils"
 )
 
 const (
@@ -231,8 +232,7 @@ func flatRepeatedList(dataValue reflect.Value, request AcsRequest, position, pre
 			if !containsTypeTag {
 				// simple param
 				key := prefix + name
-				value := dataValue.Field(i).String()
-				err = addParam(request, fieldPosition, key, value)
+				err = addParamByReflectValue(request, fieldPosition, key, dataValue.Field(i))
 				if err != nil {
 					return
 				}
@@ -248,8 +248,7 @@ func flatRepeatedList(dataValue reflect.Value, request AcsRequest, position, pre
 						elementValue := repeatedFieldValue.Index(m)
 						key := prefix + name + "." + strconv.Itoa(m+1)
 						if elementValue.Type().String() == "string" {
-							value := elementValue.String()
-							err = addParam(request, fieldPosition, key, value)
+							err = addParamByReflectValue(request, fieldPosition, key, elementValue)
 							if err != nil {
 								return
 							}
@@ -265,6 +264,17 @@ func flatRepeatedList(dataValue reflect.Value, request AcsRequest, position, pre
 		}
 	}
 	return
+}
+
+func addParamByReflectValue(request AcsRequest, position, name string, rv reflect.Value) (err error) {
+	if utils.IsEmptyValue(rv) {
+		return nil
+	}
+	strValue, errForConvert := utils.ConvertToString(rv.Interface())
+	if errForConvert != nil {
+		return err
+	}
+	return addParam(request, position, name, strValue)
 }
 
 func addParam(request AcsRequest, position, name, value string) (err error) {

--- a/sdk/utils/utils.go
+++ b/sdk/utils/utils.go
@@ -98,3 +98,52 @@ func InitStructWithDefaultTag(bean interface{}) {
 		}
 	}
 }
+
+type IZero interface {
+	IsZero() bool
+}
+
+func IsEmptyValue(v reflect.Value) bool {
+	if v.CanInterface() {
+		if zeroChecker, ok := v.Interface().(IZero); ok {
+			return zeroChecker.IsZero()
+		}
+	}
+
+	switch v.Kind() {
+	case reflect.Array, reflect.Map, reflect.Slice, reflect.String:
+		return v.Len() == 0
+	case reflect.Bool:
+		return !v.Bool()
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		return v.Int() == 0
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr:
+		return v.Uint() == 0
+	case reflect.Float32, reflect.Float64:
+		return v.Float() == 0
+	case reflect.Interface, reflect.Ptr:
+		return v.IsNil()
+	}
+	return false
+}
+
+func ConvertToString(v interface{}) (string, error) {
+	if stringer, ok := v.(fmt.Stringer); ok {
+		return stringer.String(), nil
+	}
+	rt := reflect.TypeOf(v)
+	switch rt.Kind() {
+	case reflect.String:
+		return v.(string), nil
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64, reflect.Uint, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uint8:
+		return fmt.Sprintf("%d", v), nil
+	case reflect.Bool:
+		return strconv.FormatBool(v.(bool)), nil
+	case reflect.Float32:
+		return strconv.FormatFloat(float64(v.(float32)), 'f', -1, 32), nil
+	case reflect.Float64:
+		return strconv.FormatFloat(v.(float64), 'f', -1, 64), nil
+	default:
+		return "", fmt.Errorf("unsupport type")
+	}
+}


### PR DESCRIPTION
Request 的参数还是应该保留对应的类型，以方便用户赋值，全 string 太过暴力 