### PR TITLE
删除签名算法中的无效代码

### DIFF
--- a/sdk/auth/rpc_signature_composer.go
+++ b/sdk/auth/rpc_signature_composer.go
@@ -80,12 +80,6 @@ func buildRpcStringToSign(request requests.AcsRequest) (stringToSign string) {
 		signParams[key] = value
 	}
 
-	// sort params by key
-	var paramKeySlice []string
-	for key := range signParams {
-		paramKeySlice = append(paramKeySlice, key)
-	}
-	sort.Strings(paramKeySlice)
 	stringToSign = utils.GetUrlFormedMap(signParams)
 	stringToSign = strings.Replace(stringToSign, "+", "%20", -1)
 	stringToSign = strings.Replace(stringToSign, "*", "%2A", -1)


### PR DESCRIPTION
这段代码并没有任何地方使用，实际上 utils.GetUrlFormedMap 里面调用了 url.Values.Encode() 函数，这个函数已经自带了将参数按照 key 进行排序的功能，所以没有必要再进行一次排序。