### PR TITLE
bugfix:rpc request not support req.port & set reqeust.Integer(etc.) m…

### DIFF
--- a/sdk/requests/rpc_request.go
+++ b/sdk/requests/rpc_request.go
@@ -52,7 +52,7 @@ func (request *RpcRequest) GetQueries() string {
 }
 
 func (request *RpcRequest) BuildUrl() string {
-	return strings.ToLower(request.Scheme) + "://" + request.Domain + request.BuildQueries()
+	return strings.ToLower(request.Scheme) + "://" + request.Domain + ":" + request.Port + request.BuildQueries()
 }
 
 func (request *RpcRequest) GetUrl() string {

--- a/sdk/requests/types.go
+++ b/sdk/requests/types.go
@@ -8,11 +8,11 @@ func NewInteger(integer int) Integer {
 	return Integer(strconv.Itoa(integer))
 }
 
-func (integer Integer) hasValue() bool {
+func (integer Integer) HasValue() bool {
 	return integer != ""
 }
 
-func (integer Integer) getValue() (int, error) {
+func (integer Integer) GetValue() (int, error) {
 	return strconv.Atoi(string(integer))
 }
 
@@ -20,7 +20,7 @@ func NewInteger64(integer int64) Integer {
 	return Integer(strconv.FormatInt(integer, 10))
 }
 
-func (integer Integer) getValue64() (int64, error) {
+func (integer Integer) GetValue64() (int64, error) {
 	return strconv.ParseInt(string(integer), 10, 0)
 }
 
@@ -30,11 +30,11 @@ func NewBoolean(bool bool) Boolean {
 	return Boolean(strconv.FormatBool(bool))
 }
 
-func (boolean Boolean) hasValue() bool {
+func (boolean Boolean) HasValue() bool {
 	return boolean != ""
 }
 
-func (boolean Boolean) getValue() (bool, error) {
+func (boolean Boolean) GetValue() (bool, error) {
 	return strconv.ParseBool(string(boolean))
 }
 
@@ -44,10 +44,10 @@ func NewFloat(f float64) Float {
 	return Float(strconv.FormatFloat(f, 'f', 6, 64))
 }
 
-func (float Float) hasValue() bool {
+func (float Float) HasValue() bool {
 	return float != ""
 }
 
-func (float Float) getValue() (float64, error) {
+func (float Float) GetValue() (float64, error) {
 	return strconv.ParseFloat(string(float), 64)
 }

--- a/sdk/requests/types_test.go
+++ b/sdk/requests/types_test.go
@@ -7,8 +7,8 @@ import (
 
 func TestNewInteger(t *testing.T) {
 	integer := NewInteger(123123)
-	assert.True(t, integer.hasValue())
-	value, err := integer.getValue()
+	assert.True(t, integer.HasValue())
+	value, err := integer.GetValue()
 	assert.Nil(t, err)
 	assert.Equal(t, 123123, value)
 	var expected Integer
@@ -18,8 +18,8 @@ func TestNewInteger(t *testing.T) {
 
 func TestNewInteger64(t *testing.T) {
 	long := NewInteger64(123123123123123123)
-	assert.True(t, long.hasValue())
-	value, err := long.getValue64()
+	assert.True(t, long.HasValue())
+	value, err := long.GetValue64()
 	assert.Nil(t, err)
 	assert.Equal(t, int64(123123123123123123), value)
 	var expected Integer
@@ -29,8 +29,8 @@ func TestNewInteger64(t *testing.T) {
 
 func TestNewBoolean(t *testing.T) {
 	boolean := NewBoolean(false)
-	assert.True(t, boolean.hasValue())
-	value, err := boolean.getValue()
+	assert.True(t, boolean.HasValue())
+	value, err := boolean.GetValue()
 	assert.Nil(t, err)
 	assert.Equal(t, false, value)
 	var expected Boolean
@@ -40,8 +40,8 @@ func TestNewBoolean(t *testing.T) {
 
 func TestNewFloat(t *testing.T) {
 	float := NewFloat(123123.123123)
-	assert.True(t, float.hasValue())
-	value, err := float.getValue()
+	assert.True(t, float.HasValue())
+	value, err := float.GetValue()
 	assert.Nil(t, err)
 	assert.Equal(t, 123123.123123, value)
 	var expected Float


### PR DESCRIPTION
1.  bugfix: rpc request not support req.port 
2. set reqeust.Integer(etc.) methods to public

Signed-off-by: gaort <rutong.grt@alibaba-inc.com>