### PR TITLE
Update DoAction logic to use BuildRequestWithSigner.

### DIFF
--- a/sdk/client.go
+++ b/sdk/client.go
@@ -16,16 +16,17 @@ package sdk
 
 import (
 	"fmt"
+	"net"
+	"net/http"
+	"strconv"
+	"sync"
+
 	"github.com/aliyun/alibaba-cloud-sdk-go/sdk/auth"
 	"github.com/aliyun/alibaba-cloud-sdk-go/sdk/auth/credentials"
 	"github.com/aliyun/alibaba-cloud-sdk-go/sdk/endpoints"
 	"github.com/aliyun/alibaba-cloud-sdk-go/sdk/errors"
 	"github.com/aliyun/alibaba-cloud-sdk-go/sdk/requests"
 	"github.com/aliyun/alibaba-cloud-sdk-go/sdk/responses"
-	"net"
-	"net/http"
-	"strconv"
-	"sync"
 )
 
 // this value will be replaced while build: -ldflags="-X sdk.version=x.x.x"
@@ -151,52 +152,7 @@ func (client *Client) DoAction(request requests.AcsRequest, response responses.A
 	return client.DoActionWithSigner(request, response, nil)
 }
 
-func (client *Client) BuildRequestWithSigner(request requests.AcsRequest, signer auth.Signer) (err error) {
-	// add clientVersion
-	request.GetHeaders()["x-sdk-core-version"] = Version
-
-	regionId := client.regionId
-	if len(request.GetRegionId()) > 0 {
-		regionId = request.GetRegionId()
-	}
-
-	// resolve endpoint
-	resolveParam := &endpoints.ResolveParam{
-		Domain:               request.GetDomain(),
-		Product:              request.GetProduct(),
-		RegionId:             regionId,
-		LocationProduct:      request.GetLocationServiceCode(),
-		LocationEndpointType: request.GetLocationEndpointType(),
-		CommonApi:            client.ProcessCommonRequest,
-	}
-	endpoint, err := endpoints.Resolve(resolveParam)
-	if err != nil {
-		return
-	}
-	request.SetDomain(endpoint)
-
-	// init request params
-	err = requests.InitParams(request)
-	if err != nil {
-		return
-	}
-
-	// signature
-	var finalSigner auth.Signer
-	if signer != nil {
-		finalSigner = signer
-	} else {
-		finalSigner = client.signer
-	}
-	httpRequest, err := buildHttpRequest(request, finalSigner, regionId)
-	if client.config.UserAgent != "" {
-		httpRequest.Header.Set("User-Agent", client.config.UserAgent)
-	}
-	return err
-}
-
-func (client *Client) DoActionWithSigner(request requests.AcsRequest, response responses.AcsResponse, signer auth.Signer) (err error) {
-
+func (client *Client) BuildRequestWithSigner(request requests.AcsRequest, signer auth.Signer) (httpRequest *http.Request, err error) {
 	// add clientVersion
 	request.GetHeaders()["x-sdk-core-version"] = Version
 
@@ -236,13 +192,36 @@ func (client *Client) DoActionWithSigner(request requests.AcsRequest, response r
 	} else {
 		finalSigner = client.signer
 	}
-	httpRequest, err := buildHttpRequest(request, finalSigner, regionId)
-	if client.config.UserAgent != "" {
-		httpRequest.Header.Set("User-Agent", client.config.UserAgent)
-	}
+	httpRequest, err = buildHttpRequest(request, finalSigner, regionId)
 	if err != nil {
 		return
 	}
+
+	if client.config.UserAgent != "" {
+		httpRequest.Header.Set("User-Agent", client.config.UserAgent)
+	}
+	return
+}
+
+func (client *Client) DoActionWithSigner(request requests.AcsRequest, response responses.AcsResponse, signer auth.Signer) (err error) {
+	// signature
+	var finalSigner auth.Signer
+	if signer != nil {
+		finalSigner = signer
+	} else {
+		finalSigner = client.signer
+	}
+
+	regionId := client.regionId
+	if len(request.GetRegionId()) > 0 {
+		regionId = request.GetRegionId()
+	}
+
+	httpRequest, err := client.BuildRequestWithSigner(request, finalSigner)
+	if err != nil {
+		return
+	}
+
 	var httpResponse *http.Response
 	for retryTimes := 0; retryTimes <= client.config.MaxRetryTime; retryTimes++ {
 		httpResponse, err = client.httpClient.Do(httpRequest)


### PR DESCRIPTION
Reduces code duplication, and makes it possible for client users to get
the signed httpRequest without immediately executing it.