### PR TITLE
Add obs feature to aliyun-go-sdk

### DIFF
--- a/sdk/endpoints/endpoints_config.go
+++ b/sdk/endpoints/endpoints_config.go
@@ -482,6 +482,14 @@ const endpointsJson = "{" +
 	"    \"regional_endpoint_pattern\": \"\"" +
 	"  }," +
 	"  {" +
+	"    \"code\": \"obs\"," +
+	"    \"document_id\": \"34962\"," +
+	"    \"location_service_code\": \"obs\"," +
+	"    \"regional_endpoints\": []," +
+	"    \"global_endpoint\": \"billing.aliyuncs.com\"," +
+	"    \"regional_endpoint_pattern\": \"\"" +
+	"  }," +
+	"  {" +
 	"    \"code\": \"waf\"," +
 	"    \"document_id\": \"62847\"," +
 	"    \"location_service_code\": \"waf\"," +

--- a/services/obs/client.go
+++ b/services/obs/client.go
@@ -1,0 +1,68 @@
+package obs
+
+
+
+import (
+	"github.com/aliyun/alibaba-cloud-sdk-go/sdk"
+	"github.com/aliyun/alibaba-cloud-sdk-go/sdk/auth"
+)
+
+// Client is the sdk client struct, each func corresponds to an OpenAPI
+type Client struct {
+	sdk.Client
+}
+
+// NewClient creates a sdk client with environment variables
+func NewClient() (client *Client, err error) {
+	client = &Client{}
+	err = client.Init()
+	return
+}
+
+// NewClientWithOptions creates a sdk client with regionId/sdkConfig/credential
+// this is the common api to create a sdk client
+func NewClientWithOptions(regionId string, config *sdk.Config, credential auth.Credential) (client *Client, err error) {
+	client = &Client{}
+	err = client.InitWithOptions(regionId, config, credential)
+	return
+}
+
+// NewClientWithAccessKey is a shortcut to create sdk client with accesskey
+// usage: https://help.aliyun.com/document_detail/66217.html
+func NewClientWithAccessKey(regionId, accessKeyId, accessKeySecret string) (client *Client, err error) {
+	client = &Client{}
+	err = client.InitWithAccessKey(regionId, accessKeyId, accessKeySecret)
+	return
+}
+
+// NewClientWithStsToken is a shortcut to create sdk client with sts token
+// usage: https://help.aliyun.com/document_detail/66222.html
+func NewClientWithStsToken(regionId, stsAccessKeyId, stsAccessKeySecret, stsToken string) (client *Client, err error) {
+	client = &Client{}
+	err = client.InitWithStsToken(regionId, stsAccessKeyId, stsAccessKeySecret, stsToken)
+	return
+}
+
+// NewClientWithRamRoleArn is a shortcut to create sdk client with ram roleArn
+// usage: https://help.aliyun.com/document_detail/66222.html
+func NewClientWithRamRoleArn(regionId string, accessKeyId, accessKeySecret, roleArn, roleSessionName string) (client *Client, err error) {
+	client = &Client{}
+	err = client.InitWithRamRoleArn(regionId, accessKeyId, accessKeySecret, roleArn, roleSessionName)
+	return
+}
+
+// NewClientWithEcsRamRole is a shortcut to create sdk client with ecs ram role
+// usage: https://help.aliyun.com/document_detail/66223.html
+func NewClientWithEcsRamRole(regionId string, roleName string) (client *Client, err error) {
+	client = &Client{}
+	err = client.InitWithEcsRamRole(regionId, roleName)
+	return
+}
+
+// NewClientWithRsaKeyPair is a shortcut to create sdk client with rsa key pair
+// attention: rsa key pair auth is only Japan regions available
+func NewClientWithRsaKeyPair(regionId string, publicKeyId, privateKey string, sessionExpiration int) (client *Client, err error) {
+	client = &Client{}
+	err = client.InitWithRsaKeyPair(regionId, publicKeyId, privateKey, sessionExpiration)
+	return
+}

--- a/services/obs/query_consume_detail.go
+++ b/services/obs/query_consume_detail.go
@@ -1,0 +1,54 @@
+package obs
+
+import (
+	"github.com/aliyun/alibaba-cloud-sdk-go/sdk/requests"
+	"github.com/aliyun/alibaba-cloud-sdk-go/sdk/responses"
+)
+
+type QueryConsumeDetailRequest struct {
+	*requests.RpcRequest
+	CommodityCode string `position:"Query" name:"CommodityCode" required:"false"`
+	ConsumePeriod string `position:"Query" name:"ConsumePeriod" required:"true"`
+	StartTime string `position:"Query" name:"StartTime" required:"false"`
+	EndTime string `position:"Query" name:"EndTime" required:"false"`
+	ConsumeCategory string `position:"Query" name:"ConsumeCategory" required:"false"`
+	OwnerAccount string `position:"Query" name:"OwnerAccount" required:"false"`
+	NeedDetail requests.Boolean `position:"Query" name:"NeedDetail" required:"false"`
+	PageSize requests.Integer `position:"Query" name:"PageSize" required:"false"`
+	PageMinId requests.Integer `position:"Query" name:"PageMinId" required:"false"`
+
+}
+
+type QueryConsumeDetailResponse struct {
+
+	*responses.BaseResponse
+	TotalCount int `json:"TotalCount" xml:"TotalCount"`
+	NextPageMinId int `json:"NextPageMinId" xml:"NextPageMinId"`
+	PageSize int `json:"PageSize" xml:"PageSize"`
+	ConsumeList ConsumeInstance `json:"ConsumeList" xml:"ConsumeList"`
+
+}
+
+func CreateQueryConsumeDetailRequest() (request *QueryConsumeDetailRequest)  {
+	request = &QueryConsumeDetailRequest{
+		RpcRequest: &requests.RpcRequest{},
+	}
+
+	request.InitWithApiInfo("Obs", "2016-11-11", "QueryConsumeDetail", "obs", "openAPI")
+
+	return
+}
+
+func CreateQueryConsumeDetailResponse()  (response *QueryConsumeDetailResponse){
+	response = &QueryConsumeDetailResponse{
+		BaseResponse: &responses.BaseResponse{},
+	}
+	return
+}
+
+
+func (client *Client) QueryConsumeDetail(request *QueryConsumeDetailRequest) (response *QueryConsumeDetailResponse, err error){
+	response = CreateQueryConsumeDetailResponse()
+	err = client.DoAction(request, response)
+	return
+}

--- a/services/obs/struct_consume_detail_map.go
+++ b/services/obs/struct_consume_detail_map.go
@@ -1,0 +1,10 @@
+package obs
+
+
+type ConsumeDetailMap struct {
+	ResCode string `json:"ResCode"`
+	ResFee string `json:"ResFee"`
+	ResRequireFee string`json:"ResRequireFee"`
+	ResQuantity string `json:"ResQuantity"`
+	ResFlowPackDeduct string `json:"ResFlowPackDeduct"`
+}

--- a/services/obs/struct_consume_list.go
+++ b/services/obs/struct_consume_list.go
@@ -1,0 +1,33 @@
+package obs
+
+type ConsumeInstance struct {
+	Instance []CInstance
+
+}
+
+type CInstance struct {
+	ConsumrPeriod string
+	BuyerId string
+	OwnerId string
+	CommodityCode string
+	ConsumeCategory string
+	BizId string
+	ConsumeTime int64
+	ServiceStartTime string
+	ServiceEndTime string
+	ServiceDuration string
+	InstanceId string
+	InstanceNick string
+	Tag string
+	Region string
+	InternetIp string
+	intranetIp string
+	ConsumeAmount string
+	FreeAmount string
+	RequireAmount string
+	PayStatus string
+	CashPayAmount string
+	CouponPayAmount string
+	UnclearAmount string
+	ConsumeDetail ConsumeDetailMap
+}


### PR DESCRIPTION
Hi, 
目前我将obs即关于阿里云计费的QueryConsumeDetail接口实现了一下，使用方式如下：

```

func main()  {

		obsClient, err := obs.NewClientWithAccessKey(
			"cn-shanghai",
			"secret_id",
			"secret_key")

		if err != nil {
			panic(err)
		}

		request := obs.CreateQueryConsumeDetailRequest()
		request.PageSize = requests.NewInteger(10)
		request.ConsumePeriod = "2018-10"
		request.PageMinId = requests.Integer(10)

		response, err := obsClient.QueryConsumeDetail(request)

		if err != nil {
			panic(err)
		}

	fmt.Println(response)
}

```


```
response:

HTTP/1.1 200 OK
Content-Type: application/json; charset=UTF-8
Access-Control-Allow-Methods: POST, GET, OPTIONS
Access-Control-Allow-Headers: X-Requested-With, X-Sequence, _aop_secret, _aop_signature
Access-Control-Max-Age: 172800
Date: Wed, 14 Nov 2018 10:36:04 GMT
Content-Length: 123
Access-Control-Allow-Origin: *
Server: Jetty(7.2.2.v20101205)

{"TotalCount":0,"Message":"successful.","PageSize":10,"Success":true,"Code":"Success","ConsumeList":{"ConsumeInstance":[XXX]}}


```

- 还请各位有时间review一下代码，有什么问题，还请指出，感谢~
