### PR TITLE
Added `REGION_ID` environment for UnitTest

### DIFF
--- a/integration/ecs_test.go
+++ b/integration/ecs_test.go
@@ -11,7 +11,11 @@ import (
 
 func Test_DescribeRegions(t *testing.T) {
 	request := ecs.CreateDescribeRegionsRequest()
-	client, err := ecs.NewClientWithAccessKey("cn-hangzhou", os.Getenv("ACCESS_KEY_ID"), os.Getenv("ACCESS_KEY_SECRET"))
+	client, err := ecs.NewClientWithAccessKey(
+		os.Getenv("REGION_ID"),
+		os.Getenv("ACCESS_KEY_ID"),
+		os.Getenv("ACCESS_KEY_SECRET"),
+	)
 	assert.Nil(t, err)
 	response, err := client.DescribeRegions(request)
 	assert.Nil(t, err)

--- a/integration/rds_test.go
+++ b/integration/rds_test.go
@@ -10,7 +10,9 @@ import (
 
 func Test_DescribeDBInstances(t *testing.T) {
 	client, err := rds.NewClientWithAccessKey(
-		"cn-hangzhou", os.Getenv("ACCESS_KEY_ID"), os.Getenv("ACCESS_KEY_SECRET"),
+		os.Getenv("REGION_ID"),
+		os.Getenv("ACCESS_KEY_ID"),
+		os.Getenv("ACCESS_KEY_SECRET"),
 	)
 	assert.Nil(t, err)
 	assert.NotNil(t, client)


### PR DESCRIPTION
```
env REGION_ID="cn-shanghai"         \
    ACCESS_KEY_ID="************"    \
    ACCESS_KEY_SECRET="************ \
    go test -v
```