### PR TITLE
when errcode is SignatureDoesNotMatch, prompt users that the err may …

### DIFF
--- a/sdk/errors/server_error_test.go
+++ b/sdk/errors/server_error_test.go
@@ -55,7 +55,7 @@ func TestWrapServerError(t *testing.T) {
 	m = make(map[string]string)
 	m["StringToSign"] = "match"
 	WrapServerError(se, m)
-	assert.Equal(t, "Please check you AccessKeySecret", se.Recommend())
+	assert.Equal(t, "InvalidAccessKeySecret: Please check you AccessKeySecret", se.Recommend())
 
 	err = NewServerError(400, `{"Code":"Other"}`, "comment")
 	se, ok = err.(*ServerError)

--- a/sdk/errors/signature_does_not_match_wrapper.go
+++ b/sdk/errors/signature_does_not_match_wrapper.go
@@ -27,7 +27,7 @@ func (*SignatureDostNotMatchWrapper) tryWrap(error *ServerError, wrapInfo map[st
 
 			if clientStringToSign == serverStringToSign {
 				// user secret is error
-				error.recommend = "Please check you AccessKeySecret"
+				error.recommend = "InvalidAccessKeySecret: Please check you AccessKeySecret"
 			} else {
 				debug("Client StringToSign: %s", clientStringToSign)
 				debug("Server StringToSign: %s", serverStringToSign)

--- a/sdk/errors/signature_does_not_match_wrapper_test.go
+++ b/sdk/errors/signature_does_not_match_wrapper_test.go
@@ -39,5 +39,5 @@ func TestWrapMatch(t *testing.T) {
 	m["StringToSign"] = "match"
 	wrapped := wrapper.tryWrap(se, m)
 	assert.True(t, wrapped)
-	assert.Equal(t, "Please check you AccessKeySecret", se.Recommend())
+	assert.Equal(t, "InvalidAccessKeySecret: Please check you AccessKeySecret", se.Recommend())
 }


### PR DESCRIPTION
…cause by InvalidAccessKeySecret