### PR TITLE
fix jsoniter RegisterTypeDecoder cause 'concurrent map read and map write'

### DIFF
--- a/sdk/responses/json_parser.go
+++ b/sdk/responses/json_parser.go
@@ -6,7 +6,6 @@ import (
 	"math"
 	"strconv"
 	"strings"
-	"sync"
 	"unsafe"
 
 	jsoniter "github.com/json-iterator/go"
@@ -17,18 +16,15 @@ const maxInt = int(maxUint >> 1)
 const minInt = -maxInt - 1
 
 var jsonParser jsoniter.API
-var initJson = &sync.Once{}
 
-func initJsonParserOnce() {
-	initJson.Do(func() {
-		registerBetterFuzzyDecoder()
-		jsonParser = jsoniter.Config{
-			EscapeHTML:             true,
-			SortMapKeys:            true,
-			ValidateJsonRawMessage: true,
-			CaseSensitive:          true,
-		}.Froze()
-	})
+func init() {
+	registerBetterFuzzyDecoder()
+	jsonParser = jsoniter.Config{
+		EscapeHTML:             true,
+		SortMapKeys:            true,
+		ValidateJsonRawMessage: true,
+		CaseSensitive:          true,
+	}.Froze()
 }
 
 func registerBetterFuzzyDecoder() {

--- a/sdk/responses/json_parser_test.go
+++ b/sdk/responses/json_parser_test.go
@@ -7,7 +7,6 @@ import (
 )
 
 func TestUnmarshal(t *testing.T) {
-	initJsonParserOnce()
 	from := []byte(`{}`)
 	to := &struct{}{}
 	// support auto json type trans
@@ -20,7 +19,6 @@ func TestUnmarshal(t *testing.T) {
 }
 
 func TestUnmarshal_int(t *testing.T) {
-	initJsonParserOnce()
 	to := &struct {
 		INT int
 	}{}
@@ -105,7 +103,6 @@ func TestUnmarshal_int(t *testing.T) {
 }
 
 func TestUnmarshal_uint(t *testing.T) {
-	initJsonParserOnce()
 	to := &struct {
 		UINT uint
 	}{}
@@ -136,7 +133,6 @@ func TestUnmarshal_uint(t *testing.T) {
 }
 
 func TestUnmarshal_int8(t *testing.T) {
-	initJsonParserOnce()
 	to := &struct {
 		INT8 int8
 	}{}
@@ -167,7 +163,6 @@ func TestUnmarshal_int8(t *testing.T) {
 }
 
 func TestUnmarshal_uint8(t *testing.T) {
-	initJsonParserOnce()
 	to := &struct {
 		UINT8 uint8
 	}{}
@@ -198,7 +193,6 @@ func TestUnmarshal_uint8(t *testing.T) {
 }
 
 func TestUnmarshal_int16(t *testing.T) {
-	initJsonParserOnce()
 	to := &struct {
 		INT16 int16
 	}{}
@@ -229,7 +223,6 @@ func TestUnmarshal_int16(t *testing.T) {
 }
 
 func TestUnmarshal_uint16(t *testing.T) {
-	initJsonParserOnce()
 	to := &struct {
 		UINT16 uint16
 	}{}
@@ -260,7 +253,6 @@ func TestUnmarshal_uint16(t *testing.T) {
 }
 
 func TestUnmarshal_int32(t *testing.T) {
-	initJsonParserOnce()
 	to := &struct {
 		INT32 int32
 	}{}
@@ -291,7 +283,6 @@ func TestUnmarshal_int32(t *testing.T) {
 }
 
 func TestUnmarshal_uint32(t *testing.T) {
-	initJsonParserOnce()
 	to := &struct {
 		UINT32 uint32
 	}{}
@@ -322,7 +313,6 @@ func TestUnmarshal_uint32(t *testing.T) {
 }
 
 func TestUnmarshal_int64(t *testing.T) {
-	initJsonParserOnce()
 	to := &struct {
 		INT64 int64
 	}{}
@@ -353,7 +343,6 @@ func TestUnmarshal_int64(t *testing.T) {
 }
 
 func TestUnmarshal_uint64(t *testing.T) {
-	initJsonParserOnce()
 	to := &struct {
 		UINT64 uint64
 	}{}
@@ -384,7 +373,6 @@ func TestUnmarshal_uint64(t *testing.T) {
 }
 
 func TestUnmarshal_string(t *testing.T) {
-	initJsonParserOnce()
 	to := &struct {
 		STRING string
 	}{}
@@ -437,7 +425,6 @@ func TestUnmarshal_string(t *testing.T) {
 }
 
 func TestUnmarshal_bool(t *testing.T) {
-	initJsonParserOnce()
 	to := &struct {
 		BOOL bool
 	}{}
@@ -521,7 +508,6 @@ func TestUnmarshal_bool(t *testing.T) {
 }
 
 func TestUnmarshal_array(t *testing.T) {
-	initJsonParserOnce()
 	to := &struct {
 		Array []string
 	}{}
@@ -537,7 +523,6 @@ func TestUnmarshal_array(t *testing.T) {
 }
 
 func TestUnmarshal_float32(t *testing.T) {
-	initJsonParserOnce()
 	to := &struct {
 		FLOAT32 float32
 	}{}
@@ -623,7 +608,6 @@ func TestUnmarshal_float32(t *testing.T) {
 }
 
 func TestUnmarshal_float64(t *testing.T) {
-	initJsonParserOnce()
 	to := &struct {
 		FLOAT64 float64
 	}{}
@@ -709,7 +693,6 @@ func TestUnmarshal_float64(t *testing.T) {
 }
 
 func TestUnmarshalWithArray(t *testing.T) {
-	initJsonParserOnce()
 	from := []byte(`[]`)
 	to := &struct{}{}
 	// TODO: Must support Array

--- a/sdk/responses/response.go
+++ b/sdk/responses/response.go
@@ -41,6 +41,7 @@ var debug utils.Debug
 func init() {
 	debug = utils.Init("sdk")
 }
+
 // Unmarshal object from http response body to target Response
 func Unmarshal(response AcsResponse, httpResponse *http.Response, format string) (err error) {
 	err = response.parseFromHttpResponse(httpResponse)
@@ -62,7 +63,6 @@ func Unmarshal(response AcsResponse, httpResponse *http.Response, format string)
 	}
 
 	if strings.ToUpper(format) == "JSON" {
-		initJsonParserOnce()
 		err = jsonParser.Unmarshal(response.GetHttpContentBytes(), response)
 		if err != nil {
 			err = errors.NewClientError(errors.JsonUnmarshalErrorCode, errors.JsonUnmarshalErrorMessage, err)


### PR DESCRIPTION
Calling jsoniter.RegisterTypeDecoder must be at the entrypoint of program, otherwise it will cause panic of "concurrent map read and map write".

The method jsoniter.RegisterTypeDecoder will write the field `typeDecoders` at file `github.com/json-iterator/go/reflect_extension.go`, if other goruntine call `json.Unmarshal` (`github.com/json-iterator/go`) will cause "concurrent map read and map write", because json.Unmarshal need read `typeDecoders`.