### PR TITLE
Add client.SetTransport to give users more control of httpClient

### DIFF
--- a/sdk/client.go
+++ b/sdk/client.go
@@ -123,6 +123,13 @@ func (client *Client) GetNoProxy() string {
 	return client.noProxy
 }
 
+func (client *Client) SetTransport(transport http.RoundTripper) {
+	if client.httpClient == nil {
+		client.httpClient = &http.Client{}
+	}
+	client.httpClient.Transport = transport
+}
+
 // InitWithProviderChain will get credential from the providerChain,
 // the RsaKeyPairCredential Only applicable to regionID `ap-northeast-1`,
 // if your providerChain may return a credential type with RsaKeyPairCredential,

--- a/sdk/client_test.go
+++ b/sdk/client_test.go
@@ -812,3 +812,29 @@ func TestNewClientWithBearerToken(t *testing.T) {
 	assert.Nil(t, err)
 	assert.NotNil(t, client)
 }
+
+func TestClient_SetTransport_httpTransport(t *testing.T) {
+	client, err := NewClientWithBearerToken("cn-hangzhou", "Bearer.Token")
+	assert.Nil(t, err)
+	transport := &http.Transport{}
+	client.SetTransport(transport)
+	if client.httpClient.Transport.(*http.Transport) != transport {
+		t.Fail()
+	}
+}
+
+func TestClient_SetTransport_customTransport(t *testing.T) {
+	client, err := NewClientWithBearerToken("cn-hangzhou", "Bearer.Token")
+	assert.Nil(t, err)
+	transport := &myTransport{}
+	client.SetTransport(transport)
+	if client.httpClient.Transport.(*myTransport) != transport {
+		t.Fail()
+	}
+}
+
+type myTransport struct{}
+
+func (m *myTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	return http.DefaultTransport.RoundTrip(req)
+}


### PR DESCRIPTION
Give users full control of httpClient.Transport even if it's instance of http.Transport.

Refer: https://github.com/denverdino/aliyungo/pull/369