### PR TITLE
Export Client.signer

### DIFF
--- a/sdk/client.go
+++ b/sdk/client.go
@@ -707,6 +707,10 @@ func (client *Client) GetSigner() auth.Signer {
 	return client.signer
 }
 
+func (client *Client) SetSigner(signer auth.Signer) {
+	client.signer = signer
+}
+
 func NewClient() (client *Client, err error) {
 	client = &Client{}
 	err = client.Init()

--- a/sdk/client.go
+++ b/sdk/client.go
@@ -703,6 +703,10 @@ func (client *Client) GetConfig() *Config {
 	return client.config
 }
 
+func (client *Client) GetSigner() auth.Signer {
+	return client.signer
+}
+
 func NewClient() (client *Client, err error) {
 	client = &Client{}
 	err = client.Init()

--- a/sdk/client_test.go
+++ b/sdk/client_test.go
@@ -838,3 +838,11 @@ type myTransport struct{}
 func (m *myTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	return http.DefaultTransport.RoundTrip(req)
 }
+
+func TestClient_GetSigner(t *testing.T) {
+	client, err := NewClientWithBearerToken("cn-hangzhou", "Bearer.Token")
+	assert.Nil(t, err)
+	signer := client.GetSigner()
+	assert.Equal(t, client.signer, signer)
+	assert.True(t, client.signer == signer)
+}

--- a/sdk/client_test.go
+++ b/sdk/client_test.go
@@ -846,3 +846,18 @@ func TestClient_GetSigner(t *testing.T) {
 	assert.Equal(t, client.signer, signer)
 	assert.True(t, client.signer == signer)
 }
+
+func TestClient_SetSigner(t *testing.T) {
+	c1, err := NewClientWithBearerToken("cn-hangzhou", "Bearer.Token")
+	assert.Nil(t, err)
+	oldSinger := c1.GetSigner()
+
+	c2, err := NewClientWithBearerToken("cn-hangzhou", "Bearer.Token")
+	assert.Nil(t, err)
+	newSinger := c2.GetSigner()
+
+	c1.SetSigner(newSinger)
+	assert.Equal(t, newSinger, c1.signer)
+	assert.True(t, c1.signer == newSinger)
+	assert.True(t, c1.signer != oldSinger)
+}


### PR DESCRIPTION
Use this way to allow user trigger fetch and cache token at program initialization to fix cold boot issues like #397 