### PR TITLE
Use a json iterator extension to register better fuzzy decoders (#412)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af
 	github.com/json-iterator/go v1.1.5
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
-	github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742 // indirect
+	github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742
 	github.com/smartystreets/goconvey v0.0.0-20190330032615-68dc04aab96a // indirect
 	github.com/stretchr/testify v1.3.0
 	gopkg.in/ini.v1 v1.42.0

--- a/sdk/responses/json_parser.go
+++ b/sdk/responses/json_parser.go
@@ -4,11 +4,13 @@ import (
 	"encoding/json"
 	"io"
 	"math"
+	"reflect"
 	"strconv"
 	"strings"
 	"unsafe"
 
 	jsoniter "github.com/json-iterator/go"
+	"github.com/modern-go/reflect2"
 )
 
 const maxUint = ^uint(0)
@@ -18,140 +20,143 @@ const minInt = -maxInt - 1
 var jsonParser jsoniter.API
 
 func init() {
-	registerBetterFuzzyDecoder()
 	jsonParser = jsoniter.Config{
 		EscapeHTML:             true,
 		SortMapKeys:            true,
 		ValidateJsonRawMessage: true,
 		CaseSensitive:          true,
 	}.Froze()
+
+	jsonParser.RegisterExtension(newBetterFuzzyExtension())
 }
 
-func registerBetterFuzzyDecoder() {
-	jsoniter.RegisterTypeDecoder("string", &nullableFuzzyStringDecoder{})
-	jsoniter.RegisterTypeDecoder("bool", &fuzzyBoolDecoder{})
-	jsoniter.RegisterTypeDecoder("float32", &nullableFuzzyFloat32Decoder{})
-	jsoniter.RegisterTypeDecoder("float64", &nullableFuzzyFloat64Decoder{})
-	jsoniter.RegisterTypeDecoder("int", &nullableFuzzyIntegerDecoder{func(isFloat bool, ptr unsafe.Pointer, iter *jsoniter.Iterator) {
-		if isFloat {
-			val := iter.ReadFloat64()
-			if val > float64(maxInt) || val < float64(minInt) {
-				iter.ReportError("fuzzy decode int", "exceed range")
-				return
+func newBetterFuzzyExtension() jsoniter.DecoderExtension {
+	return jsoniter.DecoderExtension{
+		reflect2.DefaultTypeOfKind(reflect.String):  &nullableFuzzyStringDecoder{},
+		reflect2.DefaultTypeOfKind(reflect.Bool):    &fuzzyBoolDecoder{},
+		reflect2.DefaultTypeOfKind(reflect.Float32): &nullableFuzzyFloat32Decoder{},
+		reflect2.DefaultTypeOfKind(reflect.Float64): &nullableFuzzyFloat64Decoder{},
+		reflect2.DefaultTypeOfKind(reflect.Int): &nullableFuzzyIntegerDecoder{func(isFloat bool, ptr unsafe.Pointer, iter *jsoniter.Iterator) {
+			if isFloat {
+				val := iter.ReadFloat64()
+				if val > float64(maxInt) || val < float64(minInt) {
+					iter.ReportError("fuzzy decode int", "exceed range")
+					return
+				}
+				*((*int)(ptr)) = int(val)
+			} else {
+				*((*int)(ptr)) = iter.ReadInt()
 			}
-			*((*int)(ptr)) = int(val)
-		} else {
-			*((*int)(ptr)) = iter.ReadInt()
-		}
-	}})
-	jsoniter.RegisterTypeDecoder("uint", &nullableFuzzyIntegerDecoder{func(isFloat bool, ptr unsafe.Pointer, iter *jsoniter.Iterator) {
-		if isFloat {
-			val := iter.ReadFloat64()
-			if val > float64(maxUint) || val < 0 {
-				iter.ReportError("fuzzy decode uint", "exceed range")
-				return
+		}},
+		reflect2.DefaultTypeOfKind(reflect.Uint): &nullableFuzzyIntegerDecoder{func(isFloat bool, ptr unsafe.Pointer, iter *jsoniter.Iterator) {
+			if isFloat {
+				val := iter.ReadFloat64()
+				if val > float64(maxUint) || val < 0 {
+					iter.ReportError("fuzzy decode uint", "exceed range")
+					return
+				}
+				*((*uint)(ptr)) = uint(val)
+			} else {
+				*((*uint)(ptr)) = iter.ReadUint()
 			}
-			*((*uint)(ptr)) = uint(val)
-		} else {
-			*((*uint)(ptr)) = iter.ReadUint()
-		}
-	}})
-	jsoniter.RegisterTypeDecoder("int8", &nullableFuzzyIntegerDecoder{func(isFloat bool, ptr unsafe.Pointer, iter *jsoniter.Iterator) {
-		if isFloat {
-			val := iter.ReadFloat64()
-			if val > float64(math.MaxInt8) || val < float64(math.MinInt8) {
-				iter.ReportError("fuzzy decode int8", "exceed range")
-				return
+		}},
+		reflect2.DefaultTypeOfKind(reflect.Int8): &nullableFuzzyIntegerDecoder{func(isFloat bool, ptr unsafe.Pointer, iter *jsoniter.Iterator) {
+			if isFloat {
+				val := iter.ReadFloat64()
+				if val > float64(math.MaxInt8) || val < float64(math.MinInt8) {
+					iter.ReportError("fuzzy decode int8", "exceed range")
+					return
+				}
+				*((*int8)(ptr)) = int8(val)
+			} else {
+				*((*int8)(ptr)) = iter.ReadInt8()
 			}
-			*((*int8)(ptr)) = int8(val)
-		} else {
-			*((*int8)(ptr)) = iter.ReadInt8()
-		}
-	}})
-	jsoniter.RegisterTypeDecoder("uint8", &nullableFuzzyIntegerDecoder{func(isFloat bool, ptr unsafe.Pointer, iter *jsoniter.Iterator) {
-		if isFloat {
-			val := iter.ReadFloat64()
-			if val > float64(math.MaxUint8) || val < 0 {
-				iter.ReportError("fuzzy decode uint8", "exceed range")
-				return
+		}},
+		reflect2.DefaultTypeOfKind(reflect.Uint8): &nullableFuzzyIntegerDecoder{func(isFloat bool, ptr unsafe.Pointer, iter *jsoniter.Iterator) {
+			if isFloat {
+				val := iter.ReadFloat64()
+				if val > float64(math.MaxUint8) || val < 0 {
+					iter.ReportError("fuzzy decode uint8", "exceed range")
+					return
+				}
+				*((*uint8)(ptr)) = uint8(val)
+			} else {
+				*((*uint8)(ptr)) = iter.ReadUint8()
 			}
-			*((*uint8)(ptr)) = uint8(val)
-		} else {
-			*((*uint8)(ptr)) = iter.ReadUint8()
-		}
-	}})
-	jsoniter.RegisterTypeDecoder("int16", &nullableFuzzyIntegerDecoder{func(isFloat bool, ptr unsafe.Pointer, iter *jsoniter.Iterator) {
-		if isFloat {
-			val := iter.ReadFloat64()
-			if val > float64(math.MaxInt16) || val < float64(math.MinInt16) {
-				iter.ReportError("fuzzy decode int16", "exceed range")
-				return
+		}},
+		reflect2.DefaultTypeOfKind(reflect.Int16): &nullableFuzzyIntegerDecoder{func(isFloat bool, ptr unsafe.Pointer, iter *jsoniter.Iterator) {
+			if isFloat {
+				val := iter.ReadFloat64()
+				if val > float64(math.MaxInt16) || val < float64(math.MinInt16) {
+					iter.ReportError("fuzzy decode int16", "exceed range")
+					return
+				}
+				*((*int16)(ptr)) = int16(val)
+			} else {
+				*((*int16)(ptr)) = iter.ReadInt16()
 			}
-			*((*int16)(ptr)) = int16(val)
-		} else {
-			*((*int16)(ptr)) = iter.ReadInt16()
-		}
-	}})
-	jsoniter.RegisterTypeDecoder("uint16", &nullableFuzzyIntegerDecoder{func(isFloat bool, ptr unsafe.Pointer, iter *jsoniter.Iterator) {
-		if isFloat {
-			val := iter.ReadFloat64()
-			if val > float64(math.MaxUint16) || val < 0 {
-				iter.ReportError("fuzzy decode uint16", "exceed range")
-				return
+		}},
+		reflect2.DefaultTypeOfKind(reflect.Uint16): &nullableFuzzyIntegerDecoder{func(isFloat bool, ptr unsafe.Pointer, iter *jsoniter.Iterator) {
+			if isFloat {
+				val := iter.ReadFloat64()
+				if val > float64(math.MaxUint16) || val < 0 {
+					iter.ReportError("fuzzy decode uint16", "exceed range")
+					return
+				}
+				*((*uint16)(ptr)) = uint16(val)
+			} else {
+				*((*uint16)(ptr)) = iter.ReadUint16()
 			}
-			*((*uint16)(ptr)) = uint16(val)
-		} else {
-			*((*uint16)(ptr)) = iter.ReadUint16()
-		}
-	}})
-	jsoniter.RegisterTypeDecoder("int32", &nullableFuzzyIntegerDecoder{func(isFloat bool, ptr unsafe.Pointer, iter *jsoniter.Iterator) {
-		if isFloat {
-			val := iter.ReadFloat64()
-			if val > float64(math.MaxInt32) || val < float64(math.MinInt32) {
-				iter.ReportError("fuzzy decode int32", "exceed range")
-				return
+		}},
+		reflect2.DefaultTypeOfKind(reflect.Int32): &nullableFuzzyIntegerDecoder{func(isFloat bool, ptr unsafe.Pointer, iter *jsoniter.Iterator) {
+			if isFloat {
+				val := iter.ReadFloat64()
+				if val > float64(math.MaxInt32) || val < float64(math.MinInt32) {
+					iter.ReportError("fuzzy decode int32", "exceed range")
+					return
+				}
+				*((*int32)(ptr)) = int32(val)
+			} else {
+				*((*int32)(ptr)) = iter.ReadInt32()
 			}
-			*((*int32)(ptr)) = int32(val)
-		} else {
-			*((*int32)(ptr)) = iter.ReadInt32()
-		}
-	}})
-	jsoniter.RegisterTypeDecoder("uint32", &nullableFuzzyIntegerDecoder{func(isFloat bool, ptr unsafe.Pointer, iter *jsoniter.Iterator) {
-		if isFloat {
-			val := iter.ReadFloat64()
-			if val > float64(math.MaxUint32) || val < 0 {
-				iter.ReportError("fuzzy decode uint32", "exceed range")
-				return
+		}},
+		reflect2.DefaultTypeOfKind(reflect.Uint32): &nullableFuzzyIntegerDecoder{func(isFloat bool, ptr unsafe.Pointer, iter *jsoniter.Iterator) {
+			if isFloat {
+				val := iter.ReadFloat64()
+				if val > float64(math.MaxUint32) || val < 0 {
+					iter.ReportError("fuzzy decode uint32", "exceed range")
+					return
+				}
+				*((*uint32)(ptr)) = uint32(val)
+			} else {
+				*((*uint32)(ptr)) = iter.ReadUint32()
 			}
-			*((*uint32)(ptr)) = uint32(val)
-		} else {
-			*((*uint32)(ptr)) = iter.ReadUint32()
-		}
-	}})
-	jsoniter.RegisterTypeDecoder("int64", &nullableFuzzyIntegerDecoder{func(isFloat bool, ptr unsafe.Pointer, iter *jsoniter.Iterator) {
-		if isFloat {
-			val := iter.ReadFloat64()
-			if val > float64(math.MaxInt64) || val < float64(math.MinInt64) {
-				iter.ReportError("fuzzy decode int64", "exceed range")
-				return
+		}},
+		reflect2.DefaultTypeOfKind(reflect.Int64): &nullableFuzzyIntegerDecoder{func(isFloat bool, ptr unsafe.Pointer, iter *jsoniter.Iterator) {
+			if isFloat {
+				val := iter.ReadFloat64()
+				if val > float64(math.MaxInt64) || val < float64(math.MinInt64) {
+					iter.ReportError("fuzzy decode int64", "exceed range")
+					return
+				}
+				*((*int64)(ptr)) = int64(val)
+			} else {
+				*((*int64)(ptr)) = iter.ReadInt64()
 			}
-			*((*int64)(ptr)) = int64(val)
-		} else {
-			*((*int64)(ptr)) = iter.ReadInt64()
-		}
-	}})
-	jsoniter.RegisterTypeDecoder("uint64", &nullableFuzzyIntegerDecoder{func(isFloat bool, ptr unsafe.Pointer, iter *jsoniter.Iterator) {
-		if isFloat {
-			val := iter.ReadFloat64()
-			if val > float64(math.MaxUint64) || val < 0 {
-				iter.ReportError("fuzzy decode uint64", "exceed range")
-				return
+		}},
+		reflect2.DefaultTypeOfKind(reflect.Uint64): &nullableFuzzyIntegerDecoder{func(isFloat bool, ptr unsafe.Pointer, iter *jsoniter.Iterator) {
+			if isFloat {
+				val := iter.ReadFloat64()
+				if val > float64(math.MaxUint64) || val < 0 {
+					iter.ReportError("fuzzy decode uint64", "exceed range")
+					return
+				}
+				*((*uint64)(ptr)) = uint64(val)
+			} else {
+				*((*uint64)(ptr)) = iter.ReadUint64()
 			}
-			*((*uint64)(ptr)) = uint64(val)
-		} else {
-			*((*uint64)(ptr)) = iter.ReadUint64()
-		}
-	}})
+		}},
+	}
 }
 
 type nullableFuzzyStringDecoder struct {

--- a/sdk/responses/json_parser_test.go
+++ b/sdk/responses/json_parser_test.go
@@ -1,8 +1,11 @@
 package responses
 
 import (
+	"reflect"
 	"testing"
 
+	jsoniter "github.com/json-iterator/go"
+	"github.com/modern-go/reflect2"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -698,5 +701,194 @@ func TestUnmarshalWithArray(t *testing.T) {
 	// TODO: Must support Array
 	// support auto json type trans
 	err := jsonParser.Unmarshal(from, to)
+	assert.NotNil(t, err)
+}
+
+func TestNewBetterFuzzyExtension(t *testing.T) {
+	betterFuzzyExtension := newBetterFuzzyExtension()
+	assert.NotNil(t, betterFuzzyExtension)
+
+	decoder := betterFuzzyExtension[reflect2.DefaultTypeOfKind(reflect.String)]
+	assert.NotNil(t, decoder)
+	assert.IsType(t, &nullableFuzzyStringDecoder{}, decoder)
+
+	decoder = betterFuzzyExtension[reflect2.DefaultTypeOfKind(reflect.Bool)]
+	assert.NotNil(t, decoder)
+	assert.IsType(t, &fuzzyBoolDecoder{}, decoder)
+
+	decoder = betterFuzzyExtension[reflect2.DefaultTypeOfKind(reflect.Float32)]
+	assert.NotNil(t, decoder)
+	assert.IsType(t, &nullableFuzzyFloat32Decoder{}, decoder)
+
+	decoder = betterFuzzyExtension[reflect2.DefaultTypeOfKind(reflect.Float64)]
+	assert.NotNil(t, decoder)
+	assert.IsType(t, &nullableFuzzyFloat64Decoder{}, decoder)
+
+	decoder = betterFuzzyExtension[reflect2.DefaultTypeOfKind(reflect.Int)]
+	assert.NotNil(t, decoder)
+	assert.IsType(t, &nullableFuzzyIntegerDecoder{}, decoder)
+
+	decoder = betterFuzzyExtension[reflect2.DefaultTypeOfKind(reflect.Uint)]
+	assert.NotNil(t, decoder)
+	assert.IsType(t, &nullableFuzzyIntegerDecoder{}, decoder)
+
+	decoder = betterFuzzyExtension[reflect2.DefaultTypeOfKind(reflect.Int8)]
+	assert.NotNil(t, decoder)
+	assert.IsType(t, &nullableFuzzyIntegerDecoder{}, decoder)
+
+	decoder = betterFuzzyExtension[reflect2.DefaultTypeOfKind(reflect.Uint8)]
+	assert.NotNil(t, decoder)
+	assert.IsType(t, &nullableFuzzyIntegerDecoder{}, decoder)
+
+	decoder = betterFuzzyExtension[reflect2.DefaultTypeOfKind(reflect.Int16)]
+	assert.NotNil(t, decoder)
+	assert.IsType(t, &nullableFuzzyIntegerDecoder{}, decoder)
+
+	decoder = betterFuzzyExtension[reflect2.DefaultTypeOfKind(reflect.Uint16)]
+	assert.NotNil(t, decoder)
+	assert.IsType(t, &nullableFuzzyIntegerDecoder{}, decoder)
+
+	decoder = betterFuzzyExtension[reflect2.DefaultTypeOfKind(reflect.Int32)]
+	assert.NotNil(t, decoder)
+	assert.IsType(t, &nullableFuzzyIntegerDecoder{}, decoder)
+
+	decoder = betterFuzzyExtension[reflect2.DefaultTypeOfKind(reflect.Uint32)]
+	assert.NotNil(t, decoder)
+	assert.IsType(t, &nullableFuzzyIntegerDecoder{}, decoder)
+
+	decoder = betterFuzzyExtension[reflect2.DefaultTypeOfKind(reflect.Int64)]
+	assert.NotNil(t, decoder)
+	assert.IsType(t, &nullableFuzzyIntegerDecoder{}, decoder)
+
+	decoder = betterFuzzyExtension[reflect2.DefaultTypeOfKind(reflect.Uint64)]
+	assert.NotNil(t, decoder)
+	assert.IsType(t, &nullableFuzzyIntegerDecoder{}, decoder)
+}
+
+func TestUnmarshalWithDefaultDecoders(t *testing.T) {
+	// should not be valid with default decoders
+	from := []byte(`{"STRING":true}`)
+	toString := &struct {
+		STRING string
+	}{}
+
+	err := jsoniter.Unmarshal(from, toString)
+	assert.NotNil(t, err)
+
+	// should not be valid with default decoders
+	from = []byte(`{"BOOL":""}`)
+	toBool := &struct {
+		BOOL bool
+	}{}
+
+	err = jsoniter.Unmarshal(from, toBool)
+	assert.NotNil(t, err)
+
+	// should not be valid with default decoders
+	from = []byte(`{"FLOAT32":""}`)
+	toFloat32 := &struct {
+		FLOAT32 float32
+	}{}
+
+	err = jsoniter.Unmarshal(from, toFloat32)
+	assert.NotNil(t, err)
+
+	// should not be valid with default decoders
+	from = []byte(`{"FLOAT64":""}`)
+	toFloat64 := &struct {
+		FLOAT64 float64
+	}{}
+
+	err = jsoniter.Unmarshal(from, toFloat64)
+	assert.NotNil(t, err)
+
+	// should not be valid with default decoders
+	from = []byte(`{"INT":""}`)
+	toInt := &struct {
+		INT int
+	}{}
+
+	err = jsoniter.Unmarshal(from, toInt)
+	assert.NotNil(t, err)
+
+	// should not be valid with default decoders
+	from = []byte(`{"UINT":""}`)
+	toUint := &struct {
+		UINT uint
+	}{}
+
+	err = jsoniter.Unmarshal(from, toUint)
+	assert.NotNil(t, err)
+
+	// should not be valid with default decoders
+	from = []byte(`{"INT8":""}`)
+	toInt8 := &struct {
+		INT8 int8
+	}{}
+
+	err = jsoniter.Unmarshal(from, toInt8)
+	assert.NotNil(t, err)
+
+	// should not be valid with default decoders
+	from = []byte(`{"UINT8":""}`)
+	toUint8 := &struct {
+		UINT8 uint8
+	}{}
+
+	err = jsoniter.Unmarshal(from, toUint8)
+	assert.NotNil(t, err)
+
+	// should not be valid with default decoders
+	from = []byte(`{"INT16":""}`)
+	toInt16 := &struct {
+		INT16 int16
+	}{}
+
+	err = jsoniter.Unmarshal(from, toInt16)
+	assert.NotNil(t, err)
+
+	// should not be valid with default decoders
+	from = []byte(`{"UINT16":""}`)
+	toUint16 := &struct {
+		UINT16 uint16
+	}{}
+
+	err = jsoniter.Unmarshal(from, toUint16)
+	assert.NotNil(t, err)
+
+	// should not be valid with default decoders
+	from = []byte(`{"INT32":""}`)
+	toInt32 := &struct {
+		INT32 int32
+	}{}
+
+	err = jsoniter.Unmarshal(from, toInt32)
+	assert.NotNil(t, err)
+
+	// should not be valid with default decoders
+	from = []byte(`{"UINT32":""}`)
+	toUint32 := &struct {
+		UINT32 uint32
+	}{}
+
+	err = jsoniter.Unmarshal(from, toUint32)
+	assert.NotNil(t, err)
+
+	// should not be valid with default decoders
+	from = []byte(`{"INT64":""}`)
+	toInt64 := &struct {
+		INT64 int64
+	}{}
+
+	err = jsoniter.Unmarshal(from, toInt64)
+	assert.NotNil(t, err)
+
+	// should not be valid with default decoders
+	from = []byte(`{"UINT64":""}`)
+	toUint64 := &struct {
+		UINT64 uint64
+	}{}
+
+	err = jsoniter.Unmarshal(from, toUint64)
 	assert.NotNil(t, err)
 }


### PR DESCRIPTION
Fixes #412.

This PR register the better fuzzy decoders with a [json iterator extension](https://godoc.org/github.com/json-iterator/go#Extension). Using an extension avoid side effects with other libraries as described in #412.