### PR TITLE
fix tests from add headers commit

### DIFF
--- a/sdk/errors/server_error_test.go
+++ b/sdk/errors/server_error_test.go
@@ -19,7 +19,7 @@ func TestServerError(t *testing.T) {
 	assert.Equal(t, "", serverError.HostId())
 	assert.Equal(t, "comment", serverError.Comment())
 	assert.Equal(t, "content", serverError.Message())
-	assert.Equal(t, "SDK.ServerError\nErrorCode: \nRecommend: comment\nRequestId: \nMessage: content", serverError.Error())
+	assert.Equal(t, "SDK.ServerError\nErrorCode: \nRecommend: comment\nRequestId: \nMessage: content\nRespHeaders: map[]", serverError.Error())
 }
 
 func TestServerErrorWithContent(t *testing.T) {
@@ -35,7 +35,7 @@ func TestServerErrorWithContent(t *testing.T) {
 	assert.Equal(t, "recommend", serverError.Recommend())
 	assert.Equal(t, "comment", serverError.Comment())
 	assert.Equal(t, "message", serverError.Message())
-	assert.Equal(t, "SDK.ServerError\nErrorCode: InvalidAK\nRecommend: commentrecommend\nRequestId: request id\nMessage: message", serverError.Error())
+	assert.Equal(t, "SDK.ServerError\nErrorCode: InvalidAK\nRecommend: commentrecommend\nRequestId: request id\nMessage: message\nRespHeaders: map[]", serverError.Error())
 }
 
 func TestWrapServerError(t *testing.T) {


### PR DESCRIPTION
Commit 591c9a2cb2cca3e05e1ca941e1d099024f1a67f8 ended up breaking the TestServerError and TestServerErrorWithContent tests.  This commit fixes the string output.