### PR TITLE
Bangkok region is missing that makes the Terraform and SDK fail | MongoDB

### DIFF
--- a/sdk/endpoints/endpoints_config.go
+++ b/sdk/endpoints/endpoints_config.go
@@ -3777,6 +3777,10 @@ const endpointsJson = `{
 					"endpoint": "mongodb.ap-southeast-3.aliyuncs.com"
 				},
 				{
+					"region": "ap-southeast-7",
+					"endpoint": "mongodb.ap-southeast-7.aliyuncs.com"
+				},
+				{
 					"region": "ap-southeast-5",
 					"endpoint": "mongodb.ap-southeast-5.aliyuncs.com"
 				},


### PR DESCRIPTION
Bangkok region is missing that makes the Terraform and SDK fail on creation of the MongoDB

Adds 
{
					"region": "ap-southeast-7",
					"endpoint": "mongodb.ap-southeast-7.aliyuncs.com"
},

This may resolve the issue of Terraform SDK failing in the Bangkok region for MongoDB