### PR TITLE
fix:在某些情况下httpResponse没有关闭（in some special case,httpResponse not close）

### DIFF
--- a/sdk/client.go
+++ b/sdk/client.go
@@ -692,6 +692,7 @@ func (client *Client) DoActionWithSigner(request requests.AcsRequest, response r
 				return
 			}
 		}
+		defer httpResponse.Body.Close()
 		if isCertificateError(err) {
 			return
 		}


### PR DESCRIPTION
DoActionWithSigner，if AutoRetry may cause httpResponse not close. the httpResponse close logic is outside the for loop in responses.Unmarshal function. if AutoRetry open and response no err but statusCode wrong.in this cause httpResponse not close. 1、if client.buildRequestWithSigner has err,it will return then cause the problem 2、if continue,httpResponse will redefined then cause the problem so add defer httpResponse.Body.Close() in for loop to solve it.

DoActionWithSigner，自动重试时有可能造成没有关闭链接的问题。
当前逻辑，代码仅在for循环之外的responses.Unmarshal中处理了httpResponse的close。但是在for循环中的最后一个逻辑-自动重试会有问题。 如果AutoRetry开启，返回正常，但是返回的statusCode大于设定值，会进入自动重试逻辑。这个重试逻辑里有两种可能。 1、client.buildRequestWithSigner时报错，会return掉，导致httpResponse没有关闭。 2、continue时，httpResponse会重新赋值，导致老的httpResponse没有关闭。