### PR TITLE
Using a Local Copy of http.DefaultClient for Isolated Configuration In instance_credentials.go

### DIFF
--- a/sdk/auth/credentials/provider/instance_credentials.go
+++ b/sdk/auth/credentials/provider/instance_credentials.go
@@ -68,7 +68,7 @@ func (p *InstanceCredentialsProvider) Resolve() (auth.Credential, error) {
 }
 
 func get(url string) (status int, content []byte, err error) {
-	httpClient := http.DefaultClient
+	httpClient := *http.DefaultClient
 	httpClient.Timeout = 1 * time.Second
 	resp, err := httpClient.Get(url)
 	if err != nil {


### PR DESCRIPTION
Declaring httpClient as a replica of http.DefaultClient instead of directly using http.DefaultClient ensures that global settings of http.DefaultClient remain unaffected, preventing any unintended consequences on other business logic and dependencies.